### PR TITLE
1428: Remove unused config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ deployment can be configured to trust.
 
 | Environment Variable                     | Description                                                                                                                                           | Example Value                                        |
 |------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| AM_REALM                                 | What realm is being used in the identity cloud                                                                                                        |                                                      |
 | IG_TEST_DIRECTORY_CA_KEYSTORE_PATH       | Relative Path from the IG working directory (`/var/ig`) to the keystore containing the CA key                                                         | /secrets/test-trusted-directory/test-trusted-dir.p12 |
 | IG_TEST_DIRECTORY_CA_KEYSTORE_TYPE       | Keystore type                                                                                                                                         | PKCS12                                               |
 | IG_TEST_DIRECTORY_CA_KEYSTORE_ALIAS      | Alias of key in the keystore to use to sign certs issued. Matches the -alias arg supplied to keytool                                                  | ca                                                   |

--- a/config/7.3.0/test-trusted-directory/ig/config/dev/config/config.json
+++ b/config/7.3.0/test-trusted-directory/ig/config/dev/config/config.json
@@ -60,25 +60,6 @@
       }
     },
     {
-      "name": "ReverseProxyHandler",
-      "type": "ReverseProxyHandler",
-      "capture": [
-        "request",
-        "response"
-      ],
-      "config": {
-        "vertx": "${vertxConfig}"
-      }
-    },
-    {
-      "name": "ReverseProxyHandlerNoCapture",
-      "type": "ReverseProxyHandler",
-      "comment": "ReverseProxyHandler with no capture decorator configuration",
-      "config": {
-        "vertx": "${vertxConfig}"
-      }
-    },
-    {
       "name": "JwtSession",
       "type": "JwtSession"
     },
@@ -118,46 +99,10 @@
       }
     },
     {
-      "name": "FRReverseProxyHandlerNoCapture",
-      "comment": "ReverseProxyHandler for calls to the FR services, with the capture decorator disabled",
-      "type": "Chain",
-      "config": {
-        "filters" : [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler" : "ReverseProxyHandlerNoCapture"
-      }
-    },
-    {
-      "name": "FRReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to the FR services",
-      "type": "Chain",
-      "config": {
-        "filters": [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler": "ReverseProxyHandler"
-      }
-    },
-    {
       "name": "SystemAndEnvSecretStore-IAM",
       "type": "SystemAndEnvSecretStore",
       "config": {
         "format": "PLAIN"
-      }
-    },
-    {
-      "name": "SecretsProvider-AmJWK",
-      "type": "SecretsProvider",
-      "config": {
-        "stores": [
-          {
-            "type": "JwkSetSecretStore",
-            "config": {
-              "jwkUrl": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/connect/jwk_uri"
-            }
-          }
-        ]
       }
     },
     {

--- a/config/7.3.0/test-trusted-directory/ig/config/prod/config/config.json
+++ b/config/7.3.0/test-trusted-directory/ig/config/prod/config/config.json
@@ -48,25 +48,6 @@
       }
     },
     {
-      "name": "ReverseProxyHandler",
-      "type": "ReverseProxyHandler",
-      "capture": [
-        "request",
-        "response"
-      ],
-      "config": {
-        "vertx": "${vertxConfig}"
-      }
-    },
-    {
-      "name": "ReverseProxyHandlerNoCapture",
-      "type": "ReverseProxyHandler",
-      "comment": "ReverseProxyHandler with no capture decorator configuration",
-      "config": {
-        "vertx": "${vertxConfig}"
-      }
-    },
-    {
       "name": "JwtSession",
       "type": "JwtSession"
     },
@@ -106,46 +87,10 @@
       }
     },
     {
-      "name": "FRReverseProxyHandlerNoCapture",
-      "comment": "ReverseProxyHandler for calls to the FR services, with the capture decorator disabled",
-      "type": "Chain",
-      "config": {
-        "filters" : [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler" : "ReverseProxyHandlerNoCapture"
-      }
-    },
-    {
-      "name": "FRReverseProxyHandler",
-      "comment": "ReverseProxyHandler for calls to the FR services",
-      "type": "Chain",
-      "config": {
-        "filters": [
-          "TransactionIdOutboundFilter"
-        ],
-        "handler": "ReverseProxyHandler"
-      }
-    },
-    {
       "name": "SystemAndEnvSecretStore-IAM",
       "type": "SystemAndEnvSecretStore",
       "config": {
         "format": "PLAIN"
-      }
-    },
-    {
-      "name": "SecretsProvider-AmJWK",
-      "type": "SecretsProvider",
-      "config": {
-        "stores": [
-          {
-            "type": "JwkSetSecretStore",
-            "config": {
-              "jwkUrl": "https://&{identity.platform.fqdn}/am/oauth2/realms/root/realms/&{am.realm}/connect/jwk_uri"
-            }
-          }
-        ]
       }
     },
     {


### PR DESCRIPTION
The following has been removed:
- SecretsProvider-AmJWK
- am.realm env var
- ReverseProxyHandler config

The Test Trusted Directory is a self-contained API which does not reverse proxy any upstream. It is not dependent on AM.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1428