### PR TITLE
1473: Update dependencies to align with SAPI-G core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,14 +42,14 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <secure-api-gateway.version>3.0.0</secure-api-gateway.version>
-        <openig.version>2024.3.0</openig.version>
-        <nimbus-jose.version>9.39.1</nimbus-jose.version>
-        <bouncy-castle.version>1.77</bouncy-castle.version>
+        <secure-api-gateway.version>3.0.1-SNAPSHOT</secure-api-gateway.version>
+        <openig.version>2024.6.0</openig.version>
+        <nimbus-jose.version>9.40</nimbus-jose.version>
+        <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 


### PR DESCRIPTION
- Parent pom 3.0.1-SNAPSHOT
- Core 3.0.1-SNAPSHOT
- OpenIG 2024.6.0
- Bouncy Castle 1.78.1
- Nimbus 9.40

https://github.com/SecureApiGateway/SecureApiGateway/issues/1473