### PR TITLE
1475: Update OpenIG docker image to 2024.6.0

### DIFF
--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2024.3.0
+FROM gcr.io/forgerock-io/ig:2024.6.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
https://github.com/SecureApiGateway/SecureApiGateway/issues/1475