### PR TITLE
1521: Update server side vertx max header config

### DIFF
--- a/config/7.3.0/test-trusted-directory/ig/config/dev/config/admin.json
+++ b/config/7.3.0/test-trusted-directory/ig/config/dev/config/admin.json
@@ -24,7 +24,7 @@
       "port": 8080,
       "vertx": {
         "maxInitialLineLength": 8192,
-        "maxHeaderSize": 16384
+        "maxTotalHeadersSize": 24576
       }
     }
   ],

--- a/config/7.3.0/test-trusted-directory/ig/config/prod/config/admin.json
+++ b/config/7.3.0/test-trusted-directory/ig/config/prod/config/admin.json
@@ -24,7 +24,7 @@
       "port": 8080,
       "vertx": {
         "maxInitialLineLength": 8192,
-        "maxHeaderSize": 16384
+        "maxTotalHeadersSize": 24576
       }
     }
   ],


### PR DESCRIPTION
Deprecated option: maxHeaderSize replaced with maxTotalHeadersSize

Configuring the new option as 24KB, as the previous config allowed a max individual header size of 16KB, typically there is one large header (a JWT etc).

https://github.com/SecureApiGateway/SecureApiGateway/issues/1521