### PR TITLE
1540: Upgrade OpenIG to 2024.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <properties>
         <secure-api-gateway.version>3.2.0</secure-api-gateway.version>
-        <openig.version>2024.6.0</openig.version>
+        <openig.version>2024.9.0</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2024.6.0
+FROM gcr.io/forgerock-io/ig:2024.9.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
Upgrade IG Version from 2024.6.0 -> 2024.9.0

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1540