### PR TITLE
1602: Sapig 400

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <secure-api-gateway.version>4.0.0</secure-api-gateway.version>
+        <secure-api-gateway.version>4.0.2-SNAPSHOT</secure-api-gateway.version>
         <openig.version>2024.11.0</openig.version>
         <nimbus-jose.version>9.41.1</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>

--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2024.9.0
+FROM gcr.io/forgerock-io/ig:2024.11.0
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
Update docker image to 2024.11.0 and use latest SAPIG core for the time being

Missed changes with docker extensions

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1602