### PR TITLE
1654: Bump FAPI parent year and individual licenses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>4.0.0</version>
+        <version>4.0.4-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/secure-api-gateway-test-trusted-directory-docker/7.3.0/ig/bin/import-pem-certs.sh
+++ b/secure-api-gateway-test-trusted-directory-docker/7.3.0/ig/bin/import-pem-certs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+# Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+# Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-docker/pom.xml
+++ b/secure-api-gateway-test-trusted-directory-docker/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/pom.xml
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+    Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksService.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/TestTrustedDirectoryClassAliasResolver.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/TestTrustedDirectoryClassAliasResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerService.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateOptions.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksServiceTest.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CaCertificateResource.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CaCertificateResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020-2024 ForgeRock AS (obst@forgerock.com)
+ * Copyright © 2020-2025 ForgeRock AS (obst@forgerock.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update Parent to 4.0.4-SNAPSHOT and run build-java

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1654