### PR TITLE
1449: issueCert route should return only new certs

### DIFF
--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksService.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/main/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksService.java
@@ -21,6 +21,7 @@ import static org.forgerock.secrets.Purpose.purpose;
 
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -68,9 +69,7 @@ public class SoftwareJwksService {
             if (existingJwks == null) {
                 return new JWKSet(List.of(signingKey, transportKey));
             } else {
-                final List<JWK> keys = existingJwks.getJWKsAsList();
-                keys.add(signingKey);
-                keys.add(transportKey);
+                final List<JWK> keys = Arrays.asList(signingKey, transportKey);
                 return new JWKSet(keys);
             }
         });

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksServiceTest.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/SoftwareJwksServiceTest.java
@@ -79,7 +79,7 @@ class SoftwareJwksServiceTest {
     }
 
     @Test
-    void shouldAppendForSoftwareJwksIfAlreadyExists() {
+    void shouldOnlyReturnNewlyCreatedCertsInJwkSet() {
         final JwsAlgorithm keyAlg = JwsAlgorithm.PS256;
 
         JWKSet softwareJwks = softwareJwksService.issueSoftwareCertificates(ORG_ID, ORG_NAME, SOFTWARE_ID, new CertificateOptions(keyAlg, 3096));
@@ -88,7 +88,7 @@ class SoftwareJwksServiceTest {
 
         JWKSet appendedSoftwareJwks = softwareJwksService.issueSoftwareCertificates(ORG_ID, ORG_NAME, SOFTWARE_ID, new CertificateOptions(keyAlg, 3096));
 
-        assertThat(appendedSoftwareJwks.getJWKsAsList()).hasSize(4);
+        assertThat(appendedSoftwareJwks.getJWKsAsList()).hasSize(2);
     }
 
     @Test

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
@@ -22,7 +22,9 @@ import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.Map;
 
 import javax.security.auth.x500.X500Principal;
@@ -170,10 +172,7 @@ public class CertificateIssuerServiceTest {
             X509Certificate cert = X509CertUtils.parse(Base64.decode(issuedJwk.getX509Chain().get(0)));
             cert.verify(caCertPublicKey);
             cert.checkValidity(new Date());
-            cert.checkValidity(new Date(LocalDate.now().plusDays(29)
-                                                        .atStartOfDay()
-                                                        .toInstant(OffsetDateTime.now().getOffset())
-                                                        .toEpochMilli()));
+            cert.checkValidity(getDateInDaysFromNow(30));
 
             final X500Principal subjectX500Principal = cert.getSubjectX500Principal();
             X500Name x500Name = new X500Name(subjectX500Principal.getName());
@@ -187,6 +186,19 @@ public class CertificateIssuerServiceTest {
         } catch (Exception e) {
             throw new IllegalStateException("Failed to validated cert was issued by CA", e);
         }
+    }
+
+    private static Date getDateInDaysFromNow(int daysFromNow) {
+        // today
+        Calendar date = new GregorianCalendar();
+        // reset hour, minutes, seconds and millis
+        date.set(Calendar.HOUR_OF_DAY, 0);
+        date.set(Calendar.MINUTE, 0);
+        date.set(Calendar.SECOND, 0);
+        date.set(Calendar.MILLISECOND, 0);
+        // next day
+        date.add(Calendar.DAY_OF_MONTH, daysFromNow);
+        return date.getTime();
     }
 
 }

--- a/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/src/test/java/com/forgerock/sapi/gateway/test/trusted/directory/ca/CertificateIssuerServiceTest.java
@@ -170,8 +170,7 @@ public class CertificateIssuerServiceTest {
             X509Certificate cert = X509CertUtils.parse(Base64.decode(issuedJwk.getX509Chain().get(0)));
             cert.verify(caCertPublicKey);
             cert.checkValidity(new Date());
-
-            cert.checkValidity(new Date(LocalDate.now().plusDays(30)
+            cert.checkValidity(new Date(LocalDate.now().plusDays(29)
                                                         .atStartOfDay()
                                                         .toInstant(OffsetDateTime.now().getOffset())
                                                         .toEpochMilli()));


### PR DESCRIPTION
Currently the issueCert route returns all of the OrgId/SoftwareId certs
in a JWKS so clients (e.g. the postman tests) can't tell which certificates
have just been issued.

This PR means that the API will return an array of JWKS with only the
newly issued certs in.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1449