### PR TITLE
1670: Move Kustomize base templates to individual repos

### DIFF
--- a/_infra/kustomize/base/configmap.yaml
+++ b/_infra/kustomize/base/configmap.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-trusted-directory-config
+data:
+  IG_TEST_DIRECTORY_ISSUER_NAME: "test-publisher"
+  IG_TEST_DIRECTORY_CA_KEYSTORE_ALIAS: "ca"
+  IG_TEST_DIRECTORY_CA_KEYSTORE_PATH: "/secrets/test-trusted-directory/test-trusted-dir-keystore.p12"
+  IG_TEST_DIRECTORY_CA_KEYSTORE_TYPE: "PKCS12"
+  IG_TEST_DIRECTORY_SIGNING_KEYSTORE_ALIAS: "jwt-signer"
+  IG_TEST_DIRECTORY_SIGNING_KEYSTORE_PATH: "/secrets/test-trusted-directory/test-trusted-dir-keystore.p12"
+  IG_TEST_DIRECTORY_SIGNING_KEYSTORE_TYPE: "PKCS12"

--- a/_infra/kustomize/base/deployment.yaml
+++ b/_infra/kustomize/base/deployment.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-trusted-directory
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-trusted-directory
+  template:
+    metadata:
+      labels:
+        app: test-trusted-directory
+    spec:
+      securityContext:
+        runAsUser: 11111
+        runAsGroup: 0
+      containers:
+        - name: test-trusted-directory
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: MY_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: test-trusted-directory-secrets
+            - configMapRef:
+                name: test-trusted-directory-config
+          volumeMounts:
+            - name: test-trusted-dir-keystore
+              mountPath: /var/ig/secrets/test-trusted-directory
+              readOnly: true
+          image: testdirectory
+          imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /kube/liveness
+              port: 8080
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /kube/readiness
+              port: 8080
+            initialDelaySeconds: 5
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 200m
+              memory: 512Mi
+            limits:
+              memory: 512Mi
+      volumes:
+        - name: test-trusted-dir-keystore
+          secret:
+            secretName: test-trusted-dir-keystore
+            optional: false
+      tolerations:
+        - key: kubernetes.io/arch
+          operator: Exists
+          effect: NoSchedule

--- a/_infra/kustomize/base/ingress.yaml
+++ b/_infra/kustomize/base/ingress.yaml
@@ -1,0 +1,35 @@
+---
+# Ingress for the Test Trusted Directory hosted by the gateway.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/auth-tls-pass-certificate-to-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-tls-secret: NAMESPACE_PLACEHOLDER/mtls-ca-certs
+    nginx.ingress.kubernetes.io/auth-tls-verify-client: optional_no_ca
+    nginx.ingress.kubernetes.io/large-client-header-buffers: "4 128k"
+    nginx.ingress.kubernetes.io/proxy-body-size: 64m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 128k
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers: 4 256k
+    nginx.ingress.kubernetes.io/proxy-busy-buffers_size: 256k
+    nginx.ingress.kubernetes.io/error-log-level: "debug"
+  name: test-trusted-directory
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: FQDN_PLACEHOLDER
+      http:
+        paths:
+          - backend:
+              service:
+                name: test-trusted-directory
+                port:
+                  number: 80
+            path: /jwkms/
+            pathType: Prefix
+  tls:
+    - hosts:
+        - FQDN_PLACEHOLDER
+      secretName: ttd-tls-cert

--- a/_infra/kustomize/base/kustomization.yaml
+++ b/_infra/kustomize/base/kustomization.yaml
@@ -1,0 +1,12 @@
+generatorOptions:
+  disableNameSuffixHash: true
+labels:
+  - includeSelectors: true
+    pairs:
+      app.kubernetes.io/name: pingid
+resources:
+  - configmap.yaml
+  - deployment.yaml
+  - ingress.yaml
+  - secret.yaml
+  - service.yaml

--- a/_infra/kustomize/base/secret.yaml
+++ b/_infra/kustomize/base/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-trusted-directory-secrets
+type: Opaque
+data:
+  # IG_METRICS_USERNAME: "dXNlcg=="
+  # IG_METRICS_PASSWORD: "cGFzc3dvcmQ="
+  # IG_TEST_DIRECTORY_CA_KEYSTORE_KEYPASS: "UGFzc3cwcmQ="
+  # IG_TEST_DIRECTORY_CA_KEYSTORE_STOREPASS: "UGFzc3cwcmQ="
+  # IG_TEST_DIRECTORY_SIGNING_KEYSTORE_STOREPASS: "UGFzc3cwcmQ="
+  # IG_TEST_DIRECTORY_SIGNING_KEYSTORE_KEYPASS: "UGFzc3cwcmQ="

--- a/_infra/kustomize/base/service.yaml
+++ b/_infra/kustomize/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-trusted-directory
+spec:
+  ports:
+    - name: test-trusted-directory
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: test-trusted-directory
+  type: ClusterIP


### PR DESCRIPTION
- Add kustomize base templates to repo, so that the overlays can call this location instead of going through multiple base repositories
- Also gives further control over names for future work

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1670