### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/_infra/kustomize/base/kustomization.yaml
+++ b/_infra/kustomize/base/kustomization.yaml
@@ -1,5 +1,10 @@
 generatorOptions:
   disableNameSuffixHash: true
+# For PINGID use only, Docker images are not public - customers will need to provide their own repo name and tag
+images:
+  - name: testdirectory
+    newName:  europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact/securebanking/sapig-test-trusted-directory
+    newTag:  latest
 labels:
   - includeSelectors: true
     pairs:


### PR DESCRIPTION
Add in image for CI/CD

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676