### PR TITLE
1682: Use new Helm files to deploy to Relenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 name := secure-api-gateway-test-trusted-directory
 repo := europe-west4-docker.pkg.dev/sbat-gcr-develop/sapig-docker-artifact
 service := sapig-test-trusted-directory
+helm_repo := forgerock-helm/secure-api-gateway/${name}/
 
 docker: build-java copy-java-dependencies conf
 ifndef tag
@@ -51,3 +52,9 @@ endif
 	helm dependency update _infra/helm/${name}
 	helm template _infra/helm/${name}
 	helm package _infra/helm/${name} --version ${version} --app-version ${version}
+
+publish_helm:
+ifndef version
+	$(error A version must be supplied, Eg. make helm version=1.0.0)
+endif
+	jf rt upload  ./*-${version}.tgz ${helm_repo}


### PR DESCRIPTION
Add helm package command into makefile

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1682