### PR TITLE
1711: Post SAPIG 5.0.0 Clean Up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,12 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-parent</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1-SNAPSHOT</version>
     </parent>
 
     <properties>
-        <secure-api-gateway.version>5.0.0</secure-api-gateway.version>
-        <openig.version>2025.6.1</openig.version>
+        <secure-api-gateway.fapi-pep-as.version>5.0.1-SNAPSHOT</secure-api-gateway.fapi-pep-as.version>
+        <openig.version>2025.9.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.41.1</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig:2025.6.1-fapi
+FROM gcr.io/forgerock-io/ig/docker-build:2025.9.0-latest-postcommit-fapi
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into

--- a/secure-api-gateway-test-trusted-directory-docker/pom.xml
+++ b/secure-api-gateway-test-trusted-directory-docker/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.forgerock.sapi.gateway</groupId>
             <artifactId>secure-api-gateway-ig-extensions</artifactId>
-            <version>${secure-api-gateway.version}</version>
+            <version>${secure-api-gateway.fapi-pep-as.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Bump parent to `5.0.1-SNAPSHOT`
- Openig to `2025.9.0-SNAPSHOT`
- FAPI-PEP-AS to `5.0.1-SNAPSHOT`
- Update dockerfile to `docker-build:2025.9.0-latest-postcommit-fapi`

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1711