### PR TITLE
OpenIG-9579: Update SAPIG pipelines to use official standalone zip and docker images

### DIFF
--- a/secure-api-gateway-test-trusted-directory-docker/Dockerfile
+++ b/secure-api-gateway-test-trusted-directory-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM gcr.io/forgerock-io/ig/docker-build:2025.9.0-latest-postcommit-fapi
+FROM gcr.io/forgerock-io/ig/docker-build:2025.9.0-latest-postcommit
 # Switching back to forgerock user, app will run as this
 USER forgerock
 # Create dir where secrets can be mounted into


### PR DESCRIPTION
Remove `-fapi` from docker image to use standard image

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9579