### PR TITLE
OPENIG-10328 Bump remaining sub-module versions for dev after release of SAPIG 5.2.0

### DIFF
--- a/secure-api-gateway-test-trusted-directory-ig-extensions/pom.xml
+++ b/secure-api-gateway-test-trusted-directory-ig-extensions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-test-trusted-directory</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>secure-api-gateway-test-trusted-directory-ig-extensions</artifactId>


### PR DESCRIPTION
Fixes missed sub-module version bump (secure-api-gateway-test-trusted-directory-ig-extensions) to 5.3.0-SNAPSHOT. Follow-up to the main post-release bump.